### PR TITLE
fix: increase HTTP polling timeout for preview server detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+-  Fixed live preview loading infinitely on slower machines due to aggressive polling timeouts.
+
 ## [1.2.0] - 2026-04-21
 
 This release anticipates changes for the release of Quarkdown v2.0.0.

--- a/src/core/quarkdownServer.ts
+++ b/src/core/quarkdownServer.ts
@@ -153,7 +153,7 @@ export class QuarkdownServer {
             url: this.url,
             maxAttempts: 30,
             delayMs: 250,
-            timeout: 250,
+            timeout: 2000,
         });
 
         if (initialCheck) {
@@ -179,7 +179,7 @@ export class QuarkdownServer {
         this.pollingTimer = setInterval(async () => {
             attempts++;
 
-            const ready = await HttpPoller.checkOnce(this.url, 200);
+            const ready = await HttpPoller.checkOnce(this.url, 2000);
             if (ready) {
                 this.logger.info('Server became ready during polling');
                 this.events?.onReady?.(this.url);

--- a/src/core/quarkdownServer.ts
+++ b/src/core/quarkdownServer.ts
@@ -39,14 +39,17 @@ export interface QuarkdownServerEvents {
  * monitors its availability through HTTP polling.
  */
 export class QuarkdownServer {
-    /** Maximum number of 1-second poll attempts before giving up on server readiness. */
+    /** Maximum number of continuous poll attempts before giving up on server readiness. */
     private static readonly MAX_CONTINUOUS_POLL_ATTEMPTS = 120;
+    /** Delay between continuous poll attempts once the initial readiness window expires. */
+    private static readonly CONTINUOUS_POLL_DELAY_MS = 1000;
 
     private readonly processManager: ProcessManager;
     private readonly config: Required<QuarkdownServerConfig>;
     private readonly logger: Logger;
     private events?: QuarkdownServerEvents;
     private pollingTimer?: NodeJS.Timeout;
+    private pollingRunId = 0;
 
     public readonly url: string;
 
@@ -168,18 +171,24 @@ export class QuarkdownServer {
 
     /**
      * Start continuous polling to detect when server becomes available.
-     * Gives up after {@link MAX_CONTINUOUS_POLL_ATTEMPTS} attempts (seconds)
-     * and emits an error to avoid polling indefinitely.
+     * Gives up after {@link MAX_CONTINUOUS_POLL_ATTEMPTS} attempts and emits
+     * an error to avoid polling indefinitely.
      */
     private startContinuousPolling(): void {
         this.stopPolling();
 
         let attempts = 0;
+        const pollingRunId = this.pollingRunId;
 
-        this.pollingTimer = setInterval(async () => {
+        const poll = async (): Promise<void> => {
             attempts++;
 
             const ready = await HttpPoller.checkOnce(this.url, 2000);
+
+            if (pollingRunId !== this.pollingRunId) {
+                return;
+            }
+
             if (ready) {
                 this.logger.info('Server became ready during polling');
                 this.events?.onReady?.(this.url);
@@ -191,16 +200,23 @@ export class QuarkdownServer {
                 this.logger.error(`Server did not become ready after ${attempts} poll attempts`);
                 this.stopPolling();
                 this.events?.onError?.('Server did not become ready in time. Please try again.');
+                return;
             }
-        }, 1000);
+
+            this.pollingTimer = setTimeout(poll, QuarkdownServer.CONTINUOUS_POLL_DELAY_MS);
+        };
+
+        void poll();
     }
 
     /**
      * Stop continuous polling.
      */
     private stopPolling(): void {
+        this.pollingRunId++;
+
         if (this.pollingTimer) {
-            clearInterval(this.pollingTimer);
+            clearTimeout(this.pollingTimer);
             this.pollingTimer = undefined;
         }
     }

--- a/src/core/quarkdownServer.ts
+++ b/src/core/quarkdownServer.ts
@@ -150,6 +150,7 @@ export class QuarkdownServer {
      */
     private async startServerMonitoring(): Promise<void> {
         this.logger.info('Monitoring server availability...');
+        const pollingRunId = this.pollingRunId;
 
         // Initial check with higher timeout tolerance
         const initialCheck = await HttpPoller.pollUntilReady({
@@ -158,6 +159,10 @@ export class QuarkdownServer {
             delayMs: 250,
             timeout: 2000,
         });
+
+        if (pollingRunId !== this.pollingRunId) {
+            return;
+        }
 
         if (initialCheck) {
             this.logger.info('Server is ready');


### PR DESCRIPTION
## Summary

Increase the HTTP polling timeout from 250ms/200ms to 2000ms in `src/core/quarkdownServer.ts` to fix Live Preview spinning indefinitely on some environments (particularly Windows).

The Quarkdown preview server starts successfully, but on some systems the first few HTTP responses take longer than 250ms (due to initial compilation/rendering overhead). This causes every poll attempt to time out, and the preview never loads despite the server being fully functional and accessible in the browser.

**Changes:**
- Initial polling timeout: 250ms → 2000ms
- Continuous polling timeout: 200ms → 2000ms

Related #24 
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/quarkdown-labs/quarkdown-vscode/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->